### PR TITLE
Invalid apec version found

### DIFF
--- a/soxs/spectra.py
+++ b/soxs/spectra.py
@@ -650,7 +650,7 @@ class ApecGenerator(object):
         if apec_vers is None:
             filedir = os.path.join(os.path.dirname(__file__), 'files')
             cfile = glob.glob("%s/apec_*_coco.fits" % filedir)[0]
-            apec_vers = cfile.split("_")[1][1:]
+            apec_vers = cfile.split("/")[-1].split("_")[1][1:]
         mylog.info("Using APEC version %s." % apec_vers)
         if nei and apec_root is None:
             raise RuntimeError("The NEI APEC tables are not supplied with "


### PR DESCRIPTION
* Occurred when using SOXS' built in apec table.
* And when user had an underscore in their python path. 